### PR TITLE
Fix #8: Use `go-away` to filter profanities 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,6 @@ linters:
     - goconst
     - godot
     - gofumpt
-    - goimports
     - mnd
     - nilerr
     - revive

--- a/cmd/lengths.go
+++ b/cmd/lengths.go
@@ -27,9 +27,9 @@ import (
 // lengthsFilename is the name of the file in the poems folder where each poem's length (in characters) is stored.
 const lengthsFilename = "lengths.csv"
 
-// writeLengths writes the poem folder's lengths (stored as a string array) to the CSV stored in the poem folder.
-func writeLengths(lengths []string, poemFolder string) error {
-	lengthsPath := filepath.Join(poemFolder, lengthsFilename)
+// writeLengths writes the poems folder's lengths (stored as a string array) to the CSV stored in the poem folder.
+func writeLengths(lengths []string, poemsFolder string) error {
+	lengthsPath := filepath.Join(poemsFolder, lengthsFilename)
 	file, createErr := os.Create(lengthsPath)
 	if createErr != nil {
 		return createErr
@@ -40,10 +40,10 @@ func writeLengths(lengths []string, poemFolder string) error {
 	return writeErr
 }
 
-// getLengths reads the lengths file in the given poem folder and returns the array of corresponding poem lengths.
-func getLengths(poemFolder string) ([]int, error) {
+// getLengths reads the lengths file in the given poems folder and returns the array of corresponding poem lengths.
+func getLengths(poemsFolder string) ([]int, error) {
 	lengths := []int{}
-	lengthsPath := filepath.Join(poemFolder, lengthsFilename)
+	lengthsPath := filepath.Join(poemsFolder, lengthsFilename)
 	file, openErr := os.Open(lengthsPath)
 	if openErr != nil {
 		return lengths, openErr

--- a/cmd/parsing.go
+++ b/cmd/parsing.go
@@ -110,29 +110,29 @@ func poemFilename(poemID int) string {
 	return "poem" + strconv.Itoa(poemID) + ".json"
 }
 
-// Split an array of poems into JSON files in the poem folder.
-func splitPoems(poems []Poem, poemFolder string) error {
-	_, folderErr := os.Stat(poemFolder)
+// Split an array of poems into JSON files in the poems folder.
+func splitPoems(poems []Poem, poemsFolder string) error {
+	_, folderErr := os.Stat(poemsFolder)
 	if os.IsNotExist(folderErr) {
-		log.Printf("Creating poem folder %s\n", poemFolder)
-		dirErr := os.Mkdir(poemFolder, 0o750)
+		log.Printf("Creating poems folder %s\n", poemsFolder)
+		dirErr := os.Mkdir(poemsFolder, 0o750)
 		if dirErr != nil {
 			return dirErr
 		}
 	} else {
-		log.Printf("Poem folder %s already exists\n", poemFolder)
+		log.Printf("Poems folder %s already exists\n", poemsFolder)
 		return nil
 	}
 	lengths := []string{}
 	for idx, poem := range poems {
 		lengths = append(lengths, fmt.Sprintf("%d", len(poem.Text)))
-		poemJSON := filepath.Join(poemFolder, poemFilename(idx))
+		poemJSON := filepath.Join(poemsFolder, poemFilename(idx))
 		poemErr := poem2json(poem, poemJSON)
 		if poemErr != nil {
 			return poemErr
 		}
 	}
-	return writeLengths(lengths, poemFolder)
+	return writeLengths(lengths, poemsFolder)
 }
 
 // setupDataFolder sets up this CLI application's data folder.
@@ -154,8 +154,8 @@ func setupDataFolder() error {
 		return dlErr
 	}
 	// Populate the "poems" folder in the data folder if not already done
-	_, poemFolderErr := os.Stat(filepath.Join(dataFolder, "poems"))
-	if os.IsNotExist(poemFolderErr) {
+	_, poemsFolderErr := os.Stat(filepath.Join(dataFolder, "poems"))
+	if os.IsNotExist(poemsFolderErr) {
 		poems, readErr := readPoemsJSON(filepath.Join(dataFolder, "poems.json"))
 		if readErr != nil {
 			return readErr

--- a/cmd/poem.go
+++ b/cmd/poem.go
@@ -26,13 +26,19 @@ import (
 	"regexp"
 	"strings"
 	"unicode"
+
+	"github.com/TwiN/go-away"
 )
 
 // regexEscapes contains the characters that need to be escaped in regexes.
 const regexEscapes = `.+*?()|[]{}^$`
 
-// blackoutRP is the regular expression pointer that matches every non-whitespace charater for blacking out.
-var blackoutRP = regexp.MustCompile(`[^\t\f\r\n\ ]`)
+var (
+	// blackoutRP is the regular expression pointer that matches every non-whitespace charater for blacking out.
+	blackoutRP = regexp.MustCompile(`[^\t\f\r\n\ ]`)
+	// Regular expression pointer that matches every non-ASCII character.
+	ASCIIRP = regexp.MustCompile("[[:^ascii:]]")
+)
 
 // A Poem in the database has a title, an author, and text.
 type Poem struct {
@@ -118,6 +124,12 @@ func msg2regex(message string) string {
 	}
 	regexString += `(.*?)\z`
 	return regexString
+}
+
+// isProfane signals whether a poem's text contains profane language.
+func isProfane(poem Poem) bool {
+	filteredText := ASCIIRP.ReplaceAllLiteralString(poem.Text, "")
+	return goaway.IsProfane(filteredText)
 }
 
 // PrintPoem prints the given (un-blacked-out) poem.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,7 @@ var (
 	Verbose       bool  // Whether to print verbose results.
 	MaxLength     = 400 // Maximum poem length to black out.
 	PrintOriginal bool  // Whether to print the original poem before blacking it out.
+	Profanities   bool  // Whether to filter out poems with offensive words while searching.
 )
 
 // rootCmd represents the base command when called without any sub-commands.
@@ -57,7 +58,8 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "V", false, "verbose output")
 	rootCmd.PersistentFlags().IntVarP(&MaxLength, "max-length", "l", MaxLength, "maximum poem length")
-	rootCmd.PersistentFlags().BoolVarP(&PrintOriginal, "print-original", "p", false, "print original poem before blacking out")
+	rootCmd.PersistentFlags().BoolVarP(&PrintOriginal, "print-original", "o", false, "print original poem before blacking out")
+	rootCmd.PersistentFlags().BoolVarP(&Profanities, "allow-profanities", "p", false, "Allow blacking out poems with profanities")
 }
 
 // runApp runs the CLI application.
@@ -77,7 +79,7 @@ func runApp(cmd *cobra.Command, args []string) {
 	if setupErr != nil {
 		log.Fatalf(setupErr.Error())
 	}
-	sp := SearchParams{runtime.NumCPU(), dataFolderPoems, blackoutRegex, MaxLength}
+	sp := SearchParams{runtime.NumCPU(), dataFolderPoems, blackoutRegex, MaxLength, Profanities}
 	poemID, err := searchPoemsFolder(sp)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/searching.go
+++ b/cmd/searching.go
@@ -113,18 +113,18 @@ func searchEveryNPoems(startID int, lengths []int, sp SearchParams, found chan i
 	found <- searchFailure
 }
 
-// canBlackout reports whether the given poem in the poem folder is:
+// canBlackout reports whether the given poem in the poems folder is:
 //
 // - shorter than the maximum length
 // - is not profane, if profanities are not allowed
 // - can be blacked out by the blackout regex.
-func canBlackout(rp *regexp.Regexp, poemFolder string, poemID int, poemLength int, maxLength int, profanities bool) (bool, error) {
+func canBlackout(rp *regexp.Regexp, poemsFolder string, poemID int, poemLength int, maxLength int, profanities bool) (bool, error) {
 	// Check poem length
 	if poemLength > maxLength {
 		return false, nil
 	}
 	// Read poem
-	poemPath := filepath.Join(poemFolder, poemFilename(poemID))
+	poemPath := filepath.Join(poemsFolder, poemFilename(poemID))
 	poem, err := json2poem(poemPath)
 	if err != nil {
 		return false, err

--- a/cmd/searching_test.go
+++ b/cmd/searching_test.go
@@ -14,28 +14,28 @@ func TestCanBlackout(t *testing.T) {
 	badRegexP, _ := regexp.Compile("xxxxxx")
 	lengths, _ := getLengths("poem_folder")
 	// Check good regex with good length -> false
-	goodRgoodL, err := canBlackout(goodRegexP, "poem_folder", 0, lengths[0], MaxInt)
+	goodRgoodL, err := canBlackout(goodRegexP, "poem_folder", 0, lengths[0], MaxInt, true)
 	if !(err == nil && goodRgoodL == true) {
 		t.Logf("Error: %s", err.Error())
 		t.Logf("Good regex with good length: %t", goodRgoodL)
 		t.Fail()
 	}
 	// Check good regex with bad length -> false
-	goodRbadL, err := canBlackout(goodRegexP, "poem_folder", 0, lengths[0], 0)
+	goodRbadL, err := canBlackout(goodRegexP, "poem_folder", 0, lengths[0], 0, true)
 	if !(err == nil && goodRbadL == false) {
 		t.Logf("Error: %s", err.Error())
 		t.Logf("Good regex with bad length: %t", goodRbadL)
 		t.Fail()
 	}
 	// Check bad regex with good length -> false
-	badRgoodL, err := canBlackout(badRegexP, "poem_folder", 0, lengths[0], MaxInt)
+	badRgoodL, err := canBlackout(badRegexP, "poem_folder", 0, lengths[0], MaxInt, true)
 	if !(err == nil && badRgoodL == false) {
 		t.Logf("Error: %s", err.Error())
 		t.Logf("Bad regex with good length: %t", badRgoodL)
 		t.Fail()
 	}
 	// Check bad regex with bad length -> false
-	badRbadL, err := canBlackout(badRegexP, "poem_folder", 0, lengths[0], 0)
+	badRbadL, err := canBlackout(badRegexP, "poem_folder", 0, lengths[0], 0, true)
 	if !(err == nil && badRbadL == false) {
 		t.Logf("Error: %s", err.Error())
 		t.Logf("Bad regex with bad length: %t", badRbadL)

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,11 @@ module github.com/vm70/blackout
 go 1.22.5
 
 require (
+	github.com/TwiN/go-away v1.6.13 // indirect
 	github.com/adrg/xdg v0.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.22.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/TwiN/go-away v1.6.13 h1:aB6l/FPXmA5ds+V7I9zdhxzpsLLUvVtEuS++iU/ZmgE=
+github.com/TwiN/go-away v1.6.13/go.mod h1:MpvIC9Li3minq+CGgbgUDvQ9tDaeW35k5IXZrF9MVas=
 github.com/adrg/xdg v0.5.0 h1:dDaZvhMXatArP1NPHhnfaQUqWBLBsmx1h1HXQdMoFCY=
 github.com/adrg/xdg v0.5.0/go.mod h1:dDdY4M4DF9Rjy4kHPeNL+ilVF+p2lK8IdM9/rTSGcI4=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -10,5 +12,7 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
 golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Breaking change: `print-original` is now `-o`, `profanities` is now `-p`.